### PR TITLE
Ensure full rx buffer is processed before resending un-ack packet

### DIFF
--- a/SleepyLoraGateway/src/main.cpp
+++ b/SleepyLoraGateway/src/main.cpp
@@ -340,6 +340,11 @@ void loop() {
       settimeofday(&tv_now, NULL);
     }
   }
+    while (!RXbuffer.isEmpty()) {
+      digitalWrite(LED_PIN, HIGH);
+      decodePacket();
+      digitalWrite(LED_PIN, LOW);
+  }
   if (pendingTx.awaitingAck && !TXbuffer.isEmpty()) {
     if (millis() - pendingTx.lastSendTime > 750) { // timeout
         if (pendingTx.retryCount < 3) {
@@ -360,11 +365,7 @@ void loop() {
         }
     }
   }
-  if (!RXbuffer.isEmpty()) {
-    digitalWrite(LED_PIN, HIGH);
-    decodePacket();
-    digitalWrite(LED_PIN, LOW);
-  }
+
   if (!TXbuffer.isEmpty() && !pendingTx.awaitingAck && (millis() - lastTX > INTER_MESSAGE_DELAY)) {
     digitalWrite(LED_PIN, HIGH);
     sendPacket();


### PR DESCRIPTION
squash silly bug, where data was sitting in RX buffer, and the timer expires causing the resend of transmit data that was un-acknowledged, the data in the buffer contained the ack. this change ensures all received messages are processed before attempting any retransmit of data. 