### PR TITLE
Add option to connect to WiFi or create an AP.

### DIFF
--- a/SleepyLoraMaster/lib/BlindMotorController/BlindMotorController.h
+++ b/SleepyLoraMaster/lib/BlindMotorController/BlindMotorController.h
@@ -132,9 +132,9 @@ public:
     uint8_t getPwmMax() const { return pwmMax; }
     // Set/get PWM frequency
     void setPwmFrequency(uint32_t freq) {
-        // DRV8833: recommended 100Hz to 20kHz
+        // DRV8833: recommended 100Hz to 20kHz, but allow up to 40kHz for experimentation
         if (freq < 100) freq = 100;
-        if (freq > 20000) freq = 20000;
+        if (freq > 40000) freq = 40000;
         pwmFrequency = freq;
         ledcSetup(pwmChannel, pwmFrequency, 8); // Immediately apply new frequency
         saveAllSettings();

--- a/SleepyLoraMaster/src/web_portal.cpp
+++ b/SleepyLoraMaster/src/web_portal.cpp
@@ -32,13 +32,56 @@ void onLoadFileUpload(AsyncWebServerRequest *request, String filename, size_t in
 
 extern bool hexToBytes(const char*, uint8_t*, size_t);
 
+// WiFi config variables
+String wifi_ssid = "";
+String wifi_pass = "";
+bool wifi_enable = false;
+String wifi_status = "WiFi not configured.";
+
+// Helper to load/save WiFi config from NVM
+void loadWiFiConfig() {
+  prefs.begin("loracfg", true);
+  wifi_ssid = prefs.getString("wifi_ssid", "");
+  wifi_pass = prefs.getString("wifi_pass", "");
+  wifi_enable = prefs.getBool("wifi_enable", false);
+  prefs.end();
+}
+void saveWiFiConfig() {
+  prefs.begin("loracfg", false);
+  prefs.putString("wifi_ssid", wifi_ssid);
+  prefs.putString("wifi_pass", wifi_pass);
+  prefs.putBool("wifi_enable", wifi_enable);
+  prefs.end();
+}
+
 void startConfigAPAndWebserver(BlindMotorController& blind) {
   Serial.println("[DEBUG] Starting Config AP and Webserver...");
-  WiFi.mode(WIFI_AP);
-  bool apResult = WiFi.softAP("SleepyLoRaMaster", "blind1234");
-  Serial.printf("[DEBUG] softAP result: %s\n", apResult ? "success" : "fail");
-  Serial.print("[DEBUG] AP IP: ");
-  Serial.println(WiFi.softAPIP());
+  loadWiFiConfig();
+  if (wifi_enable && wifi_ssid.length() > 0) {
+    WiFi.mode(WIFI_STA);
+    // Use deviceID from main.cpp for consistent naming
+    extern uint32_t deviceID;
+    char hostname[32];
+    snprintf(hostname, sizeof(hostname), "SleepyLoRaMaster_%08lX", (unsigned long)deviceID);
+    WiFi.setHostname(hostname); // Set before WiFi.begin
+    WiFi.begin(wifi_ssid.c_str(), wifi_pass.c_str());
+    unsigned long startAttempt = millis();
+    wifi_status = "Connecting to WiFi...";
+    while (WiFi.status() != WL_CONNECTED && millis() - startAttempt < 8000) {
+      delay(200);
+    }
+    if (WiFi.status() == WL_CONNECTED) {
+      wifi_status = String("Connected: ") + WiFi.localIP().toString();
+    } else {
+      wifi_status = "WiFi connection failed. Starting AP mode.";
+      WiFi.mode(WIFI_AP);
+      WiFi.softAP("SleepyLoRaMaster", "blind1234");
+    }
+  } else {
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP("SleepyLoRaMaster", "blind1234");
+    wifi_status = String("AP IP: ") + WiFi.softAPIP().toString();
+  }
   setupWebPortal(server, blind);
   server.begin();
   Serial.println("[DEBUG] Webserver started on port 80");
@@ -47,6 +90,7 @@ void startConfigAPAndWebserver(BlindMotorController& blind) {
 void stopConfigAPAndWebserver() {
   Serial.println("[DEBUG] Stopping Webserver and AP...");
   server.end();
+  WiFi.disconnect(true);
   WiFi.mode(WIFI_OFF);
   configMode = false;
   Serial.println("[DEBUG] Webserver stopped, WiFi off, configMode=false");
@@ -172,6 +216,10 @@ String renderTemplate(const char* tpl) {
     html.replace("{{SLAVE_LIST}}", renderSlaveList());
     html.replace("{{ENGAGE_SAMPLES}}", String(blindPtr ? blindPtr->getEngageSampleCount() : 0));
     html.replace("{{ENGAGE_SAMPLE_COUNT}}", String(blindPtr ? blindPtr->getEngageSampleCount() : 0));
+    html.replace("{{WIFI_SSID}}", wifi_ssid);
+    html.replace("{{WIFI_PASS}}", wifi_pass);
+    html.replace("{{WIFI_ENABLE}}", wifi_enable ? "checked" : "");
+    html.replace("{{WIFI_STATUS}}", wifi_status);
     return html;
 }
 
@@ -618,5 +666,12 @@ pre.ascii-art { text-align: center; font-size: 1.1em; margin-bottom: 18px; color
         // Insert ASCII art and replace any template variables
         helpHtml.replace("{{ASCII_ART}}", String(BLIND_ASCII_ART));
         request->send(200, "text/html", helpHtml);
+    });
+    server.on("/set_wifi", HTTP_POST, [](AsyncWebServerRequest *request){
+        wifi_ssid = request->getParam("wifi_ssid", true)->value();
+        wifi_pass = request->getParam("wifi_pass", true)->value();
+        wifi_enable = request->hasParam("wifi_enable", true);
+        saveWiFiConfig();
+        request->redirect("/");
     });
 }

--- a/SleepyLoraMaster/src/web_portal.h
+++ b/SleepyLoraMaster/src/web_portal.h
@@ -5,3 +5,9 @@
 void setupWebPortal(AsyncWebServer& server, BlindMotorController& blind);
 void startConfigAPAndWebserver(BlindMotorController& blind);
 void stopConfigAPAndWebserver();
+
+// WiFi config keys
+extern String wifi_ssid;
+extern String wifi_pass;
+extern bool wifi_enable;
+extern String wifi_status;

--- a/SleepyLoraMaster/src/web_templates.cpp
+++ b/SleepyLoraMaster/src/web_templates.cpp
@@ -165,6 +165,18 @@ Status: <span id='blindstatus'>{{BLIND_STATUS}}</span> | Calibration: <span id='
         <div style="font-size:0.95em; color:#666;">You can set keys and gateway manually above, or load them from a JSON file exported from another device.</div>
       </div>
     </div>
+    <div class="advanced-section" style="margin-top:18px;">
+      <div class="adv-toggle" onclick="toggleWiFi()">WiFi Settings &#9660;</div>
+      <div id="wifi-section" style="display:none; padding-left:10px;">
+        <form method='POST' action='/set_wifi' style='margin-bottom:10px;'>
+          <div class="form-row"><label for='wifi_ssid'>SSID:</label><input type='text' name='wifi_ssid' id='wifi_ssid' value='{{WIFI_SSID}}' maxlength='32' style='width:180px;'></div>
+          <div class="form-row"><label for='wifi_pass'>Password:</label><input type='password' name='wifi_pass' id='wifi_pass' value='{{WIFI_PASS}}' maxlength='64' style='width:180px;'></div>
+          <div class="form-row"><input type='checkbox' name='wifi_enable' id='wifi_enable' {{WIFI_ENABLE}}> <label for='wifi_enable'>Connect to WiFi (otherwise AP mode)</label></div>
+          <button type='submit' style='margin-left:12px;'>Save WiFi Settings</button>
+        </form>
+        <div id="wifi-status" style="font-size:0.95em; color:#666;">{{WIFI_STATUS}}</div>
+      </div>
+    </div>
   </div>
   <div id="slider-container">
     <input type="range" min="0" max="100" value="{{BLIND_POS}}" class="vertical-slider" id="blindSlider" orient="vertical">
@@ -277,6 +289,18 @@ function toggleSlaves() {
   } else {
     slaves.style.display = 'none';
     toggle.innerHTML = 'Slave Devices &#9660;'; // ▼
+  }
+}
+
+function toggleWiFi() {
+  var wifi = document.getElementById('wifi-section');
+  var toggle = document.querySelector('.adv-toggle[onclick="toggleWiFi()"]');
+  if (wifi.style.display === 'none' || wifi.style.display === '') {
+    wifi.style.display = 'block';
+    toggle.innerHTML = 'WiFi Settings &#9650;'; // ▲
+  } else {
+    wifi.style.display = 'none';
+    toggle.innerHTML = 'WiFi Settings &#9660;'; // ▼
   }
 }
 
@@ -424,7 +448,8 @@ window.addEventListener('DOMContentLoaded', function() {
     { id: 'pwm-settings', toggle: 'togglePWM' },
     { id: 'slaves-section', toggle: 'toggleSlaves' },
     { id: 'ota-section', toggle: 'toggleOTA' },
-    { id: 'keys-section', toggle: 'toggleKeys' }
+    { id: 'keys-section', toggle: 'toggleKeys' },
+    { id: 'wifi-section', toggle: 'toggleWiFi' }
   ];
   sections.forEach(function(section) {
     var elem = document.getElementById(section.id);


### PR DESCRIPTION
was frustrating disconnecting from my router and connecting to the blinds AP every 2 mins during testing, so added the option to connect the blinds to my router for configuration. currently the most basic implementation where you need to manually type in the SSID and password. the values are stored in nvm, so not hard coded. unticking the checkbox allows the blind to create an AP. and if Wi-Fi doesn't connect it falls back to creating an AP too